### PR TITLE
Update PyQt5 version requirement to >= 5.15

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -7,7 +7,7 @@ urllib3
 pyttsx3
 PyInstaller
 baidu-aip
-PyQt5==5.14
+PyQt5>=5.15
 PyQt5-sip
 PyQt5-stubs
 onnxruntime


### PR DESCRIPTION
在安装依赖时遇到了问题。错误信息显示 PyQt5==5.14 版本有一个无效的 pyproject.toml 配置文件，导致 pip 无法处理它。

这是一个已知的兼容性问题。

方案：更新 PyQt5 版本 将 PyQt5 版本升级到更新的版本（如 5.15.x），这些版本已经修复了构建配置问题。